### PR TITLE
🔊 Display error information from response meta

### DIFF
--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -67,7 +67,7 @@
                 </field>
                 <field id="support_url" translate="label comment" type="label" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Support</label>
-                    <comment><![CDATA[<a href="https://help.myparcel.com/home/integrations#Integrations-Magento" target="_blank">https://help.myparcel.com/home/integrations</a>]]></comment>
+                    <comment><![CDATA[<a href="https://help.myparcel.com/home/integrations-1#Integrations-Magento" target="_blank">https://help.myparcel.com/home/integrations-1</a>]]></comment>
                 </field>
             </group>
         </section>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="MyParcelCOM_Magento" setup_version="2.0.0"/>
+    <module name="MyParcelCOM_Magento" setup_version="2.0.2"/>
 </config>


### PR DESCRIPTION
Instead of the registration message containing an api-specification error with `See meta for details` we now parse this:

![Screenshot from 2024-08-14 14-47-31](https://github.com/user-attachments/assets/f6fd3963-2b36-44f8-9b80-e9d5f18af470)
